### PR TITLE
Collections are sometimes arrays not hashes

### DIFF
--- a/lib/DPLibrary.rb
+++ b/lib/DPLibrary.rb
@@ -8,6 +8,7 @@ module DPLibrary
   autoload :Base, 'DPLibrary/base'
   autoload :DocumentCollection, 'DPLibrary/document_collection'
   autoload :Collection, 'DPLibrary/collection'
+  autoload :CollectionItem, 'DPLibrary/collection_item'
   autoload :Document, 'DPLibrary/document'
   autoload :Provider, 'DPLibrary/provider'
   autoload :OriginalRecord, 'DPLibrary/original_record'

--- a/lib/DPLibrary/collection.rb
+++ b/lib/DPLibrary/collection.rb
@@ -1,17 +1,23 @@
 module DPLibrary
   class Collection
-    attr_accessor :id,
-                  :title,
-                  :name
+    attr_accessor :collection_items
 
-    def initialize(hash)
-      set_values(hash)
+    def initialize(collection_response)
+      set_values(collection_response)
     end
 
-    def set_values(collection_hash)
-      self.id = collection_hash['id']
-      self.title = collection_hash['title']
-      self.name = collection_hash['name']
+    def set_values(collection_response)
+      @collection_items = []
+      if (collection_response.is_a?(Array))
+        @collection_items = collection_response.map {|h| create_collection_item(h)}
+      else
+        @collection_items << CollectionItem.new(collection_response)
+      end
+      @collection_items
+    end
+
+    def create_collection_item(collection_item_hash)
+      CollectionItem.new(collection_item_hash)
     end
   end
 end

--- a/lib/DPLibrary/collection_item.rb
+++ b/lib/DPLibrary/collection_item.rb
@@ -1,0 +1,17 @@
+module DPLibrary
+  class CollectionItem
+    attr_accessor :id,
+                  :title,
+                  :name
+
+    def initialize(collection_hash)
+      set_values(collection_hash)
+    end
+
+    def set_values(collection_hash)
+      self.id = collection_hash['id']
+      self.title = collection_hash['title']
+      self.name = collection_hash['name']
+    end
+  end
+end

--- a/lib/DPLibrary/document.rb
+++ b/lib/DPLibrary/document.rb
@@ -48,8 +48,8 @@ module DPLibrary
       OriginalRecord.new(original_record_hash)
     end
 
-    def create_collection(collection_hash)
-      Collection.new(collection_hash)
+    def create_collection(collection_response)
+      Collection.new(collection_response)
     end
   end
 end


### PR DESCRIPTION
Just started playing with this gem - thanks for putting it together. 

I noticed certain queries were breaking due to collection responses being arrays in some cases. This is correct behavior according to the [docs](http://dp.la/info/developers/codex/responses/field-reference/#docs): 

sourceResource.collection = "Array of URIs of collection or aggregation of which SourceResource is a part"

I added a collection_item class and moved the collection attributes down to that level. I also renamed "collection_hash" to "collection_response" in the document class since an array is technically not a hash. 

Thanks again.
