### PR TITLE
Handle documents without collections

### DIFF
--- a/lib/DPLibrary/document.rb
+++ b/lib/DPLibrary/document.rb
@@ -49,7 +49,7 @@ module DPLibrary
     end
 
     def create_collection(collection_response)
-      Collection.new(collection_response)
+      collection_response.nil? ? nil : Collection.new(collection_response)
     end
   end
 end


### PR DESCRIPTION
Many document responses contain no sourceResource.collection field
leading to a crash because every Document instance tries to
instantiate a Collection. Document#create_collection can just return nil
when this field is not present.
