### PR TITLE
Add intermediateProvider, use specific ID path

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ Let's get started!
 :score, :original_record
 ```
 
+You can retrieve multiple records by ID by passing an array for the `:id`
+parameter, like this:
+```
+@documents_collection = DPLibrary::DocumentCollection.new({id: ['id1', 'id2']})
+```
+
 Now there are many types of parameters you can pass in the
 DocumentCollection initialize method. For a complete list, check out the
 [DPLA API Reference](http://dp.la/info/developers).

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Let's get started!
 
 ## Attributes for documents
 :id, :url, :source, :title, :description, :subject, :language, :format,
-:type, :publisher, :creaetor, :provider, :collection, :score,
-:original_record
+:type, :publisher, :creaetor, :provider, :collection, :intermediate_provider,
+:score, :original_record
 ```
 
 Now there are many types of parameters you can pass in the
@@ -113,6 +113,7 @@ isShownAt
 object
 provider.@id
 provider.name
+intermediateProvider
 ```
 
 ## ToDo's

--- a/lib/DPLibrary/document.rb
+++ b/lib/DPLibrary/document.rb
@@ -13,6 +13,7 @@ module DPLibrary
                     :creator,
                     :provider,
                     :collection,
+                    :intermediate_provider,
                     :original_record,
                     :score
 
@@ -25,6 +26,7 @@ module DPLibrary
       self.id = hash['id']
       self.url = hash['isShownAt']
       self.source = hash['dataProvider']
+      self.intermediate_provider = hash['intermediateProvider']
       self.title = hash['sourceResource']['title']
       self.description = hash['sourceResource']['description']
       self.subject = hash['sourceResource']['subject']

--- a/lib/DPLibrary/document_collection.rb
+++ b/lib/DPLibrary/document_collection.rb
@@ -14,8 +14,30 @@ module DPLibrary
     end
 
     private
+
     def find(parameters)
-      get('items', parameters)
+      p = path!(parameters)
+      get(p, parameters)
+    end
+
+    ##
+    # Return the appropriate URI path, which depends upon whether IDs are given
+    #
+    # Remove an `id' parameter from the parameters if it exists, because it
+    # will become part of the path, and should not be included in the
+    # querystring parameters.
+    #
+    # @param [Hash] parameters  Query parameters
+    # @return [String]
+    # @api private
+    #
+    def path!(parameters)
+      if parameters.include? :id
+        id = parameters.delete(:id)
+        "items/#{Array(id).join(',')}"
+      else
+        'items'
+      end
     end
 
     def set_method(values)

--- a/spec/DPLibrary/document_collection_spec.rb
+++ b/spec/DPLibrary/document_collection_spec.rb
@@ -1,1 +1,41 @@
 require 'spec_helper'
+
+describe DPLibrary::DocumentCollection do
+  let (:base_response_json) do
+    { 'count' => 0, 'start' => 1, 'limit' => 1, 'docs' => [] }
+  end
+  let (:response_body) { JSON.dump(base_response_json) }
+
+  describe '#initialize' do
+
+    context 'with a string :id parameter' do
+      it 'results in a request for items/<id>' do
+        expect_any_instance_of(described_class)
+          .to receive(:get)
+          .with('items/1abc', {})
+          .and_return(response_body)
+        dc = described_class.new(id: '1abc')
+      end
+    end
+
+    context 'with an array :id parameter' do
+      it 'results in a request for items/<id>,<id>' do
+        expect_any_instance_of(described_class)
+          .to receive(:get)
+          .with('items/1abc,2def', {})
+          .and_return(response_body)
+        dc = described_class.new(id: ['1abc', '2def'])
+      end
+    end
+
+    context 'with no :id parameter' do
+      it 'results in a request for "items" with querystring params' do
+        expect_any_instance_of(described_class)
+          .to receive(:get)
+          .with('items', {:'sourceResource.title' => 'ducks'})
+          .and_return(response_body)
+        dc = described_class.new(:'sourceResource.title' => 'ducks')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hello, again. This PR contains two changes.

* Add support for the `intermediateProvider` property, which does not appear in many providers' records, but does show up some higher-volume ones, like Internet Archive.
* For queries on specific IDs, use the URL path `/items/<id>`, which also takes a comma-separated list of `id`s. You can now pass an array of IDs in the `:id` parameter to `DocumentCollection#initialize`.