### PR TITLE
Fix field name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ isShownAt
 object
 provider.@id
 provider.name
-intermediateProvider
+intermediate_provider
 ```
 
 ## ToDo's


### PR DESCRIPTION
Change `intermediateProvider` to `intermediate_provider`.
